### PR TITLE
capture final auto measure rest

### DIFF
--- a/04 MEI cleaning/improveMusic.xsl
+++ b/04 MEI cleaning/improveMusic.xsl
@@ -761,6 +761,12 @@
         </xsl:copy>
     </xsl:template>
     
+    <xsl:template match="mei:rest[@dur='' and count(parent::mei:layer/mei:*)=1 and count(ancestor::mei:staff/mei:layer) = 1]" mode="lastRun">
+        <xsl:element name="mRest" namespace="http://www.music-encoding.org/ns/mei">
+            <xsl:attribute name="xml:id" select="generate-id()"></xsl:attribute>
+        </xsl:element>
+    </xsl:template>
+    
     <xsl:template match="mei:mRest/@dur" mode="lastRun"/>
   
     <xsl:template match="mei:mSpace/@dur" mode="lastRun"/>


### PR DESCRIPTION
measure rests automatically generated by finale resulted in a rest with
dur=''
Now these get transformed to mRest without dur if their parent::layer
and ancestor::staff have exactly one child each.
